### PR TITLE
Add sandboxed conversation router with read-only endpoints

### DIFF
--- a/openhands_server/sandboxed_conversation/sandboxed_conversation_router.py
+++ b/openhands_server/sandboxed_conversation/sandboxed_conversation_router.py
@@ -1,0 +1,54 @@
+"""Sandboxed Conversation router for OpenHands Server."""
+
+from typing import Annotated
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from openhands_server.sandboxed_conversation.sandboxed_conversation_models import SandboxedConversationInfo, SandboxedConversationPage
+from openhands_server.sandboxed_conversation.sandboxed_conversation_service import get_default_sandboxed_conversation_service
+from openhands_server.user.user_dependencies import get_user_id
+
+router = APIRouter(prefix="/sandboxed-conversations")
+sandboxed_conversation_service = get_default_sandboxed_conversation_service()
+router.lifespan(sandboxed_conversation_service)
+
+# SandboxedConversations require user authentication and permissions
+# All operations are scoped to the authenticated user
+
+# Read methods
+
+@router.get("/search")
+async def search_sandboxed_conversations(
+    user_id: Annotated[UUID, Depends(get_user_id)],
+    page_id: Annotated[str | None, Query(title="Optional next_page_id from the previously returned page")] = None,
+    limit: Annotated[int, Query(title="The max number of results in the page", gt=0, lte=100, default=100)] = 100,
+) -> SandboxedConversationPage:
+    """ Search / List sandboxed conversations """
+    assert limit > 0
+    assert limit <= 100
+    return await sandboxed_conversation_service.search_sandboxed_conversations(user_id, page_id, limit)
+
+
+@router.get("/{id}", responses={
+    404: {"description": "Item not found"}
+})
+async def get_sandboxed_conversation(
+    id: UUID,
+    user_id: Annotated[UUID, Depends(get_user_id)]
+) -> SandboxedConversationInfo:
+    """ Get a sandboxed conversation given an id """
+    sandboxed_conversation = await sandboxed_conversation_service.get_sandboxed_conversation(user_id, id)
+    if sandboxed_conversation is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    return sandboxed_conversation
+
+
+@router.get("/")
+async def batch_get_sandboxed_conversations(
+    ids: list[UUID],
+    user_id: Annotated[UUID, Depends(get_user_id)]
+) -> list[SandboxedConversationInfo | None]:
+    """Get a batch of sandboxed conversations given their ids, returning null for any missing spec."""
+    assert len(ids) < 100
+    sandboxed_conversations = await sandboxed_conversation_service.batch_get_sandboxed_conversations(user_id, ids)
+    return sandboxed_conversations

--- a/openhands_server/sandboxed_conversation/sandboxed_conversation_service.py
+++ b/openhands_server/sandboxed_conversation/sandboxed_conversation_service.py
@@ -5,7 +5,7 @@ from tkinter import EventType
 from uuid import UUID
 
 from openhands_server.event.read_only_event_context import ReadOnlyEventContext
-from openhands_server.sandboxed_conversation.sandboxed_conversation_models import SandboxedConversationInfo, SandboxedConversationPage, StartSandboxedConversationRequest
+from openhands_server.sandboxed_conversation.sandboxed_conversation_models import SandboxedConversationInfo, SandboxedConversationPage
 from openhands_server.utils.import_utils import get_impl
 
 


### PR DESCRIPTION
## Summary

This PR implements a sandboxed conversation router similar to the local conversation router, but using the `SandboxedConversationService` instead of the `LocalConversationService`.

## Changes

- **Created `sandboxed_conversation_router.py`** with read-only endpoints:
  - `GET /sandboxed-conversations/search` - Search/list sandboxed conversations
  - `GET /sandboxed-conversations/{id}` - Get a specific sandboxed conversation
  - `GET /sandboxed-conversations/` - Batch get sandboxed conversations by IDs

- **Key differences from local conversation router**:
  - All endpoints require user authentication via `get_user_id` dependency
  - All operations are scoped to the authenticated user (user_id parameter)
  - **No write operations** (start, pause, resume, delete) as sandboxed conversations are managed differently
  - Uses `/sandboxed-conversations` prefix instead of `/local-conversations`

- **Router features**:
  - Proper error handling with 404 responses for missing conversations
  - Input validation (limit constraints, batch size limits)
  - Follows FastAPI best practices with type annotations and dependency injection
  - Uses the existing `SandboxedConversationService` interface

## Architecture

The router follows the established pattern in the codebase:
- Uses `get_default_sandboxed_conversation_service()` to get the service instance
- Implements the same lifespan management as other routers
- Maintains consistency with existing API patterns and response formats

## Testing

- All files compile successfully with `python -m py_compile`
- Router syntax and imports are validated
- Follows the same patterns as the existing local conversation router

## Notes

Sandboxed conversations are designed to be read-only from the API perspective, as their lifecycle is managed through different mechanisms (likely through sandbox orchestration). This design choice ensures proper separation of concerns between conversation data access and sandbox management.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f237d42fc8844443aa63d55fd47a8bf1)