### PR TITLE
Note about session API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,6 @@ For advanced development (adding deps, updating the spec file, debugging builds)
 ### WebSocket API
 - `WS /ws` - Real-time communication with the agent
 
-## Security
-
-### Session API Key
-Inside a sandbox, conversations are run locally, and there is a Session API key for the sandbox that needs provided.
-
-**Note**: the Session API key is occasionally sent to the client.
-
 ## About
 
 REST/WebSocket interface for OpenHands AI Agent, providing programmatic access to agent capabilities.

--- a/openhands_server/sdk_server/middleware.py
+++ b/openhands_server/sdk_server/middleware.py
@@ -35,7 +35,13 @@ class LocalhostCORSMiddleware(CORSMiddleware):
 
 
 class ValidateSessionAPIKeyMiddleware(BaseHTTPMiddleware):
-    """Middleware to disable caching for all routes by adding appropriate headers"""
+    """Middleware to validate session API key for all requests.
+
+    Inside a sandbox, conversations are run locally, and there is a Session API key
+    for the sandbox that needs provided.
+
+    Note: the Session API key is occasionally sent to the client.
+    """
 
     def __init__(self, app: ASGIApp, session_api_key: str) -> None:
         super().__init__(app)


### PR DESCRIPTION
Just a quick note, because in v0 this is sent to the client, right?

I don’t know if we want it to continue to be the case, but I’d just make this detail clear quick so we don’t feel a false sense of security.