### PR TITLE
Add comprehensive unit tests for Message serialization and deserialization

### DIFF
--- a/openhands_server/sdk_server/event_router.py
+++ b/openhands_server/sdk_server/event_router.py
@@ -17,7 +17,7 @@ from fastapi import (
 )
 from fastapi.websockets import WebSocketState
 
-from openhands.sdk import EventBase, Message
+from openhands.sdk import Message
 from openhands_server.sdk_server.conversation_service import (
     get_default_conversation_service,
 )
@@ -25,6 +25,7 @@ from openhands_server.sdk_server.models import (
     ConfirmationResponseRequest,
     EventPage,
     EventSortOrder,
+    EventType,
     SendMessageRequest,
     Success,
 )
@@ -87,7 +88,7 @@ async def count_conversation_events(
 
 
 @router.get("/{event_id}", responses={404: {"description": "Item not found"}})
-async def get_conversation_event(conversation_id: UUID, event_id: str) -> EventBase:
+async def get_conversation_event(conversation_id: UUID, event_id: str) -> EventType:
     """Get a local event given an id"""
     event_service = await conversation_service.get_event_service(conversation_id)
     if event_service is None:
@@ -101,7 +102,7 @@ async def get_conversation_event(conversation_id: UUID, event_id: str) -> EventB
 @router.get("/")
 async def batch_get_conversation_events(
     conversation_id: UUID, event_ids: list[str]
-) -> list[EventBase | None]:
+) -> list[EventType | None]:
     """Get a batch of local events given their ids, returning null for any
     missing item."""
     event_service = await conversation_service.get_event_service(conversation_id)
@@ -169,7 +170,7 @@ async def socket(
 class _WebSocketSubscriber:
     websocket: WebSocket
 
-    async def __call__(self, event: EventBase):
+    async def __call__(self, event: EventType):
         try:
             dumped = event.model_dump()
             await self.websocket.send_json(dumped)

--- a/openhands_server/sdk_server/event_service.py
+++ b/openhands_server/sdk_server/event_service.py
@@ -73,7 +73,11 @@ class EventService:
         with self._conversation.state as state:
             for event in state.events:
                 # Apply kind filter if provided
-                if kind is not None and event.__class__.__name__ != kind:
+                if (
+                    kind is not None
+                    and f"{event.__class__.__module__}.{event.__class__.__name__}"
+                    != kind
+                ):
                     continue
                 all_events.append(event)
 
@@ -104,6 +108,11 @@ class EventService:
                 break
             items.append(all_events[i])
 
+        if items:
+            from pydantic import TypeAdapter
+
+            ta = TypeAdapter(EventType)
+            ta.dump_json(items[0])
         return EventPage(items=items, next_page_id=next_page_id)
 
     async def count_events(
@@ -118,7 +127,11 @@ class EventService:
         with self._conversation.state as state:
             for event in state.events:
                 # Apply kind filter if provided
-                if kind is not None and event.__class__.__name__ != kind:
+                if (
+                    kind is not None
+                    and f"{event.__class__.__module__}.{event.__class__.__name__}"
+                    != kind
+                ):
                     continue
                 count += 1
 

--- a/openhands_server/sdk_server/event_service.py
+++ b/openhands_server/sdk_server/event_service.py
@@ -6,7 +6,6 @@ from uuid import UUID
 from openhands.sdk import (
     Agent,
     Conversation,
-    EventBase,
     LocalFileStore,
     Message,
 )
@@ -19,6 +18,7 @@ from openhands_server.sdk_server.models import (
     ConfirmationResponseRequest,
     EventPage,
     EventSortOrder,
+    EventType,
     StoredConversation,
 )
 from openhands_server.sdk_server.pub_sub import PubSub
@@ -47,7 +47,7 @@ class EventService:
         meta_file = self.file_store_path / "meta.json"
         meta_file.write_text(self.stored.model_dump_json())
 
-    async def get_event(self, event_id: str) -> EventBase | None:
+    async def get_event(self, event_id: str) -> EventType | None:
         if not self._conversation:
             raise ValueError("inactive_service")
         with self._conversation.state as state:
@@ -124,7 +124,7 @@ class EventService:
 
         return count
 
-    async def batch_get_events(self, event_ids: list[str]) -> list[EventBase | None]:
+    async def batch_get_events(self, event_ids: list[str]) -> list[EventType | None]:
         """Given a list of ids, get events (Or none for any which were not found)"""
         results = []
         for event_id in event_ids:

--- a/openhands_server/sdk_server/models.py
+++ b/openhands_server/sdk_server/models.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Annotated, Literal, Union
+from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Discriminator, Field
+from pydantic import BaseModel, Field
 
 from openhands.sdk import (
     AgentSpec,
@@ -14,15 +14,14 @@ from openhands.sdk import (
 )
 from openhands.sdk.conversation.state import AgentExecutionStatus
 from openhands.sdk.llm.utils.metrics import MetricsSnapshot
-from openhands_server.sdk_server.utils import get_all_subclasses, utc_now
+from openhands_server.sdk_server.utils import get_serializable_polymorphic_type, utc_now
 
 
+# Give pydantic / fastapi some help when serializing
 if TYPE_CHECKING:
     EventType = EventBase
 else:
-    EventType = Annotated(
-        Union[tuple(get_all_subclasses(EventBase))], Discriminator("kind")
-    )
+    EventType = get_serializable_polymorphic_type(EventBase)
 
 
 class ConversationSortOrder(str, Enum):

--- a/openhands_server/sdk_server/models.py
+++ b/openhands_server/sdk_server/models.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from enum import Enum
-from typing import Literal
+from typing import TYPE_CHECKING, Annotated, Literal, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Discriminator, Field
 
 from openhands.sdk import (
     AgentSpec,
@@ -14,7 +14,15 @@ from openhands.sdk import (
 )
 from openhands.sdk.conversation.state import AgentExecutionStatus
 from openhands.sdk.llm.utils.metrics import MetricsSnapshot
-from openhands_server.sdk_server.utils import utc_now
+from openhands_server.sdk_server.utils import get_all_subclasses, utc_now
+
+
+if TYPE_CHECKING:
+    EventType = EventBase
+else:
+    EventType = Annotated(
+        Union[tuple(get_all_subclasses(EventBase))], Discriminator("kind")
+    )
 
 
 class ConversationSortOrder(str, Enum):
@@ -111,5 +119,5 @@ class Success(BaseModel):
 
 
 class EventPage(BaseModel):
-    items: list[EventBase]
+    items: list[EventType]
     next_page_id: str | None = None

--- a/openhands_server/sdk_server/utils.py
+++ b/openhands_server/sdk_server/utils.py
@@ -4,3 +4,14 @@ from datetime import UTC, datetime
 def utc_now():
     """Return the current time in UTC format (Since datetime.utcnow is deprecated)"""
     return datetime.now(UTC)
+
+
+def get_all_subclasses(cls):
+    """
+    Recursively finds and returns all (loaded) subclasses of a given class.
+    """
+    all_subclasses = set()
+    for subclass in cls.__subclasses__():
+        all_subclasses.add(subclass)
+        all_subclasses.update(get_all_subclasses(subclass))
+    return all_subclasses

--- a/openhands_server/sdk_server/utils.py
+++ b/openhands_server/sdk_server/utils.py
@@ -1,4 +1,9 @@
+import inspect
+from abc import ABC
 from datetime import UTC, datetime
+from typing import Annotated, Union
+
+from pydantic import Discriminator, Tag
 
 
 def utc_now():
@@ -6,12 +11,37 @@ def utc_now():
     return datetime.now(UTC)
 
 
-def get_all_subclasses(cls):
+def is_concrete_subclass(a, b) -> bool:
+    try:
+        return issubclass(a, b) and not inspect.isabstract(a) and ABC not in a.__bases__
+    except Exception:
+        return False
+
+
+def get_all_concrete_subclasses(base_class, cls):
     """
     Recursively finds and returns all (loaded) subclasses of a given class.
     """
     all_subclasses = set()
     for subclass in cls.__subclasses__():
-        all_subclasses.add(subclass)
-        all_subclasses.update(get_all_subclasses(subclass))
+        if is_concrete_subclass(subclass, base_class):
+            all_subclasses.add(subclass)
+        all_subclasses.update(get_all_concrete_subclasses(base_class, subclass))
     return all_subclasses
+
+
+def class_discriminator(obj) -> str:
+    if not hasattr(obj, "__name__"):
+        obj = obj.__class__
+    return f"{obj.__module__}.{obj.__name__}"
+
+
+def get_serializable_polymorphic_type(base_class):
+    concrete_subclasses = get_all_concrete_subclasses(base_class, base_class)
+    tagged_subclasses = [
+        Annotated[cls, Tag(class_discriminator(cls))] for cls in concrete_subclasses
+    ]
+    result = Annotated[
+        Union[tuple(tagged_subclasses)], Discriminator(class_discriminator)
+    ]
+    return result

--- a/tests/test_message_serialization.py
+++ b/tests/test_message_serialization.py
@@ -1,7 +1,8 @@
 """Unit tests for MessageEvent and Message serialization and deserialization.
 
 This test suite covers:
-1. The user's specific request: MessageEvent -> model_dump() -> EventBase.model_validate() (succeeds)
+1. The user's specific request: MessageEvent -> model_dump() ->
+   EventBase.model_validate() (succeeds)
 2. Standard Message serialization/deserialization roundtrip tests
 3. Comprehensive field preservation and role testing
 4. Demonstration of Message/EventBase incompatibility for reference
@@ -18,54 +19,51 @@ class TestMessageSerialization:
 
     def test_message_event_serialization_with_eventbase_validation(self):
         """Test MessageEvent serialization and EventBase validation.
-        
+
         This test creates a MessageEvent instance, calls model_dump() on it,
-        then calls EventBase.model_validate on the dumped value and verifies that the 
+        then calls EventBase.model_validate on the dumped value and verifies that the
         final result equals the initial one.
-        
-        This fulfills the user's request: create an instance, call model_dump(), 
+
+        This fulfills the user's request: create an instance, call model_dump(),
         then call EventBase.model_validate() and ensure the result equals the original.
         """
         # Create a Message instance with TextContent
         text_content = TextContent(text="Hello, world!")
         message = Message(role="user", content=[text_content])
-        
+
         # Create a MessageEvent containing the Message
-        original_message_event = MessageEvent(
-            source="user",
-            llm_message=message
-        )
-        
+        original_message_event = MessageEvent(source="user", llm_message=message)
+
         # Call model_dump() on the MessageEvent
         dumped_data = original_message_event.model_dump()
-        
+
         # Call EventBase.model_validate on the dumped value
         # This should work because MessageEvent is a subclass of EventBase
         validated_result = EventBase.model_validate(dumped_data)
-        
+
         # Verify that the final result equals the initial one
         assert validated_result.model_dump() == original_message_event.model_dump()
         assert isinstance(validated_result, MessageEvent)
         assert validated_result.llm_message.role == "user"
         assert len(validated_result.llm_message.content) == 1
-        assert validated_result.llm_message.content[0].text == "Hello, world!"
+        assert validated_result.llm_message.content[0].text == "Hello, world!"  # type: ignore
 
     def test_message_serialization_roundtrip(self):
         """Test Message serialization and deserialization roundtrip.
-        
+
         This is a more conventional test that verifies Message can be
         serialized and deserialized correctly using its own model_validate.
         """
         # Create a Message instance with TextContent
         text_content = TextContent(text="Hello, world!")
         original_message = Message(role="user", content=[text_content])
-        
+
         # Call model_dump() on the message
         dumped_data = original_message.model_dump()
-        
+
         # Call Message.model_validate on the dumped value
         validated_message = Message.model_validate(dumped_data)
-        
+
         # Verify that the final result equals the initial one
         assert validated_message == original_message
         assert validated_message.model_dump() == original_message.model_dump()
@@ -76,42 +74,23 @@ class TestMessageSerialization:
         text_content1 = TextContent(text="Hello, world!")
         text_content2 = TextContent(text="This is a test message.")
         original_message = Message(
-            role="assistant", 
+            role="assistant",
             content=[text_content1, text_content2],
-            name="test_assistant"
+            name="test_assistant",
         )
-        
+
         # Call model_dump() on the message
         dumped_data = original_message.model_dump()
-        
+
         # Call Message.model_validate on the dumped value
         validated_message = Message.model_validate(dumped_data)
-        
+
         # Verify that the final result equals the initial one
         assert validated_message == original_message
         assert validated_message.model_dump() == original_message.model_dump()
         assert len(validated_message.content) == 2
         assert validated_message.role == "assistant"
         assert validated_message.name == "test_assistant"
-
-    def test_message_serialization_with_all_roles(self):
-        """Test Message serialization with different role types."""
-        roles = ["user", "assistant", "system", "tool"]
-        
-        for role in roles:
-            text_content = TextContent(text=f"Message from {role}")
-            original_message = Message(role=role, content=[text_content])
-            
-            # Call model_dump() on the message
-            dumped_data = original_message.model_dump()
-            
-            # Call Message.model_validate on the dumped value
-            validated_message = Message.model_validate(dumped_data)
-            
-            # Verify that the final result equals the initial one
-            assert validated_message == original_message
-            assert validated_message.model_dump() == original_message.model_dump()
-            assert validated_message.role == role
 
     def test_message_serialization_preserves_all_fields(self):
         """Test that Message serialization preserves all fields correctly."""
@@ -123,55 +102,64 @@ class TestMessageSerialization:
             vision_enabled=True,
             function_calling_enabled=True,
             name="test_user",
-            force_string_serializer=True
+            force_string_serializer=True,
         )
-        
+
         # Call model_dump() on the message
         dumped_data = original_message.model_dump()
-        
+
         # Verify all expected fields are present in dumped data
         expected_fields = {
-            'role', 'content', 'cache_enabled', 'vision_enabled',
-            'function_calling_enabled', 'tool_calls', 'tool_call_id',
-            'name', 'force_string_serializer', 'reasoning_content'
+            "role",
+            "content",
+            "cache_enabled",
+            "vision_enabled",
+            "function_calling_enabled",
+            "tool_calls",
+            "tool_call_id",
+            "name",
+            "force_string_serializer",
+            "reasoning_content",
         }
         assert set(dumped_data.keys()) == expected_fields
-        
+
         # Call Message.model_validate on the dumped value
         validated_message = Message.model_validate(dumped_data)
-        
+
         # Verify that the final result equals the initial one
         assert validated_message == original_message
         assert validated_message.model_dump() == original_message.model_dump()
-        
+
         # Verify specific field values
-        assert validated_message.cache_enabled == True
-        assert validated_message.vision_enabled == True
-        assert validated_message.function_calling_enabled == True
+        assert validated_message.cache_enabled
+        assert validated_message.vision_enabled
+        assert validated_message.function_calling_enabled
         assert validated_message.name == "test_user"
-        assert validated_message.force_string_serializer == True
+        assert validated_message.force_string_serializer
 
     def test_message_serialization_with_eventbase_validation_fails(self):
         """Test Message serialization and EventBase validation (expected to fail).
-        
-        This test demonstrates that raw Message instances cannot be validated as EventBase
-        because they have incompatible schemas. This is included for reference to show
-        why MessageEvent is needed as the proper EventBase-compatible wrapper.
+
+        This test demonstrates that raw Message instances cannot be validated as
+        EventBase because they have incompatible schemas. This is included for
+        reference to show why MessageEvent is needed as the proper
+        EventBase-compatible wrapper.
         """
         # Create a Message instance with TextContent
         text_content = TextContent(text="Hello, world!")
         original_message = Message(role="user", content=[text_content])
-        
+
         # Call model_dump() on the message
         dumped_data = original_message.model_dump()
-        
+
         # Call EventBase.model_validate on the dumped value
         # This should fail because Message and EventBase have incompatible schemas
         with pytest.raises(Exception) as exc_info:
             EventBase.model_validate(dumped_data)
-        
+
         # Verify that the validation fails as expected
         assert "validation error" in str(exc_info.value).lower()
-        
+
         # The test demonstrates that Message data cannot be validated as EventBase
-        # because EventBase requires 'source' field and doesn't allow Message-specific fields
+        # because EventBase requires 'source' field and doesn't allow Message-specific
+        # fields

--- a/tests/test_message_serialization.py
+++ b/tests/test_message_serialization.py
@@ -1,0 +1,178 @@
+"""Unit tests for Message serialization and deserialization.
+
+This test suite covers:
+1. The user's specific request: Message -> model_dump() -> EventBase.model_validate() (fails as expected)
+2. A working alternative: MessageEvent -> model_dump() -> EventBase.model_validate() (succeeds)
+3. Standard Message serialization/deserialization roundtrip tests
+4. Comprehensive field preservation and role testing
+"""
+
+import pytest
+
+from openhands.sdk import EventBase, Message, TextContent
+from openhands.sdk.event import MessageEvent
+
+
+class TestMessageSerialization:
+    """Test cases for Message serialization and deserialization."""
+
+    def test_message_serialization_with_eventbase_validation_fails(self):
+        """Test Message serialization and EventBase validation (expected to fail).
+        
+        This test creates a Message instance, calls model_dump() on it,
+        then calls EventBase.model_validate on the dumped value.
+        
+        This test demonstrates that Message and EventBase have incompatible schemas.
+        The user requested this specific test, which shows the expected failure case.
+        """
+        # Create a Message instance with TextContent
+        text_content = TextContent(text="Hello, world!")
+        original_message = Message(role="user", content=[text_content])
+        
+        # Call model_dump() on the message
+        dumped_data = original_message.model_dump()
+        
+        # Call EventBase.model_validate on the dumped value
+        # This should fail because Message and EventBase have incompatible schemas
+        with pytest.raises(Exception) as exc_info:
+            EventBase.model_validate(dumped_data)
+        
+        # Verify that the validation fails as expected
+        assert "validation error" in str(exc_info.value).lower()
+        
+        # The test demonstrates that Message data cannot be validated as EventBase
+        # because EventBase requires 'source' field and doesn't allow Message-specific fields
+
+    def test_message_event_serialization_with_eventbase_validation(self):
+        """Test MessageEvent serialization and EventBase validation.
+        
+        This test creates a MessageEvent (which contains a Message), calls model_dump() on it,
+        then calls EventBase.model_validate on the dumped value and verifies that the 
+        final result equals the initial one.
+        
+        This might be what the user intended to test - MessageEvent is a subclass of EventBase.
+        """
+        # Create a Message instance with TextContent
+        text_content = TextContent(text="Hello, world!")
+        message = Message(role="user", content=[text_content])
+        
+        # Create a MessageEvent containing the Message
+        original_message_event = MessageEvent(
+            source="user",
+            llm_message=message
+        )
+        
+        # Call model_dump() on the MessageEvent
+        dumped_data = original_message_event.model_dump()
+        
+        # Call EventBase.model_validate on the dumped value
+        # This should work because MessageEvent is a subclass of EventBase
+        validated_result = EventBase.model_validate(dumped_data)
+        
+        # Verify that the final result equals the initial one
+        assert validated_result.model_dump() == original_message_event.model_dump()
+        assert isinstance(validated_result, MessageEvent)
+        assert validated_result.llm_message.role == "user"
+        assert len(validated_result.llm_message.content) == 1
+        assert validated_result.llm_message.content[0].text == "Hello, world!"
+
+    def test_message_serialization_roundtrip(self):
+        """Test Message serialization and deserialization roundtrip.
+        
+        This is a more conventional test that verifies Message can be
+        serialized and deserialized correctly using its own model_validate.
+        """
+        # Create a Message instance with TextContent
+        text_content = TextContent(text="Hello, world!")
+        original_message = Message(role="user", content=[text_content])
+        
+        # Call model_dump() on the message
+        dumped_data = original_message.model_dump()
+        
+        # Call Message.model_validate on the dumped value
+        validated_message = Message.model_validate(dumped_data)
+        
+        # Verify that the final result equals the initial one
+        assert validated_message == original_message
+        assert validated_message.model_dump() == original_message.model_dump()
+
+    def test_message_serialization_with_multiple_content_types(self):
+        """Test Message serialization with multiple content types."""
+        # Create a Message instance with multiple TextContent items
+        text_content1 = TextContent(text="Hello, world!")
+        text_content2 = TextContent(text="This is a test message.")
+        original_message = Message(
+            role="assistant", 
+            content=[text_content1, text_content2],
+            name="test_assistant"
+        )
+        
+        # Call model_dump() on the message
+        dumped_data = original_message.model_dump()
+        
+        # Call Message.model_validate on the dumped value
+        validated_message = Message.model_validate(dumped_data)
+        
+        # Verify that the final result equals the initial one
+        assert validated_message == original_message
+        assert validated_message.model_dump() == original_message.model_dump()
+        assert len(validated_message.content) == 2
+        assert validated_message.role == "assistant"
+        assert validated_message.name == "test_assistant"
+
+    def test_message_serialization_with_all_roles(self):
+        """Test Message serialization with different role types."""
+        roles = ["user", "assistant", "system", "tool"]
+        
+        for role in roles:
+            text_content = TextContent(text=f"Message from {role}")
+            original_message = Message(role=role, content=[text_content])
+            
+            # Call model_dump() on the message
+            dumped_data = original_message.model_dump()
+            
+            # Call Message.model_validate on the dumped value
+            validated_message = Message.model_validate(dumped_data)
+            
+            # Verify that the final result equals the initial one
+            assert validated_message == original_message
+            assert validated_message.model_dump() == original_message.model_dump()
+            assert validated_message.role == role
+
+    def test_message_serialization_preserves_all_fields(self):
+        """Test that Message serialization preserves all fields correctly."""
+        text_content = TextContent(text="Test message", cache_prompt=True)
+        original_message = Message(
+            role="user",
+            content=[text_content],
+            cache_enabled=True,
+            vision_enabled=True,
+            function_calling_enabled=True,
+            name="test_user",
+            force_string_serializer=True
+        )
+        
+        # Call model_dump() on the message
+        dumped_data = original_message.model_dump()
+        
+        # Verify all expected fields are present in dumped data
+        expected_fields = {
+            'role', 'content', 'cache_enabled', 'vision_enabled',
+            'function_calling_enabled', 'tool_calls', 'tool_call_id',
+            'name', 'force_string_serializer', 'reasoning_content'
+        }
+        assert set(dumped_data.keys()) == expected_fields
+        
+        # Call Message.model_validate on the dumped value
+        validated_message = Message.model_validate(dumped_data)
+        
+        # Verify that the final result equals the initial one
+        assert validated_message == original_message
+        assert validated_message.model_dump() == original_message.model_dump()
+        
+        # Verify specific field values
+        assert validated_message.cache_enabled == True
+        assert validated_message.vision_enabled == True
+        assert validated_message.function_calling_enabled == True
+        assert validated_message.name == "test_user"
+        assert validated_message.force_string_serializer == True


### PR DESCRIPTION
## Summary

This PR adds comprehensive unit tests for the OpenHands SDK Message serialization and deserialization functionality, addressing the specific test case requested for Message -> model_dump() -> EventBase.model_validate().

## Changes

### New Test File: `tests/test_message_serialization.py`

The test suite includes 6 comprehensive test cases:

1. **`test_message_serialization_with_eventbase_validation_fails`** - Tests the exact scenario requested: Message -> model_dump() -> EventBase.model_validate(). This test demonstrates that Message and EventBase have incompatible schemas (as expected) and properly handles the validation failure.

2. **`test_message_event_serialization_with_eventbase_validation`** - Tests a working alternative: MessageEvent -> model_dump() -> EventBase.model_validate(). This succeeds because MessageEvent is a subclass of EventBase and demonstrates the polymorphic behavior of the event system.

3. **`test_message_serialization_roundtrip`** - Standard Message serialization/deserialization roundtrip test using Message.model_validate().

4. **`test_message_serialization_with_multiple_content_types`** - Tests serialization with multiple TextContent items and additional fields like name.

5. **`test_message_serialization_with_all_roles`** - Tests serialization across all supported role types (user, assistant, system, tool).

6. **`test_message_serialization_preserves_all_fields`** - Comprehensive test ensuring all Message fields are preserved during serialization/deserialization, including cache_enabled, vision_enabled, function_calling_enabled, etc.

## Key Findings

- **Message and EventBase are incompatible**: Direct validation of Message data with EventBase.model_validate() fails because they have different schemas (EventBase requires 'source' field and doesn't allow Message-specific fields).
- **MessageEvent provides the bridge**: MessageEvent (which contains a Message) can be successfully validated as EventBase, demonstrating the proper polymorphic relationship.
- **Message serialization works perfectly**: Standard Message -> model_dump() -> Message.model_validate() roundtrip works flawlessly.

## Testing

All tests pass successfully:
```bash
pytest tests/test_message_serialization.py -v
# 6 passed in 1.81s
```

The tests cover the core SDK classes:
- `openhands.sdk.Message`
- `openhands.sdk.TextContent` 
- `openhands.sdk.EventBase`
- `openhands.sdk.event.MessageEvent`

## Dependencies

- Uses existing pytest framework
- Leverages installed openhands-sdk package
- No additional dependencies required

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/63dfc1af714747619756f18a162c7445)