### PR TITLE
Fix SecretStr redaction issue in AppServerConfig JSON serialization

### DIFF
--- a/openhands_server/config.py
+++ b/openhands_server/config.py
@@ -111,7 +111,11 @@ def get_global_config() -> AppServerConfig:
             print("⚙️  Generating Default OpenHands App Server Config")
             _global_config = AppServerConfig()
 
-            # Save the comnfig because the master key is required between restarts
-            config_path.write_text(_global_config.model_dump_json())
+            # Save the config because the master key is required between restarts
+            # We need to explicitly include secret values for persistence
+            config_dict = _global_config.model_dump(mode='json')
+            # Manually include the secret value for the master key
+            config_dict['master_key'] = _global_config.master_key.get_secret_value()
+            config_path.write_text(json.dumps(config_dict, indent=2))
 
     return _global_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,13 @@ Unit tests for the configuration system, focusing on get_global_config function
 and JSON configuration loading with environment variable overrides.
 """
 
+import json
+import os
+import tempfile
+from pathlib import Path
+
 from openhands_server.config import (
+    CONFIG_FILE_PATH_ENV,
     AppServerConfig,
     get_global_config,
 )
@@ -16,3 +22,51 @@ class TestConfig:
         """Test that Config is immutable (frozen)."""
         config = get_global_config()
         assert isinstance(config, AppServerConfig)
+
+    def test_master_key_persistence_in_config_file(self):
+        """Test that the master key is correctly saved and loaded from config file."""
+        
+        # Create a temporary directory for the test
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file_path = Path(temp_dir) / "test_config.json"
+            
+            # Set the environment variable to use our test config file
+            original_config_path = os.environ.get(CONFIG_FILE_PATH_ENV)
+            os.environ[CONFIG_FILE_PATH_ENV] = str(config_file_path)
+            
+            try:
+                # Clear any existing global config
+                import openhands_server.config
+                openhands_server.config._global_config = None
+                
+                # Generate a new config (this should create the file)
+                config1 = get_global_config()
+                master_key1 = config1.master_key.get_secret_value()
+                
+                # Verify the config file was created and contains the master key
+                assert config_file_path.exists(), "Config file should be created"
+                
+                # Read the config file and verify the master key is not redacted
+                with open(config_file_path, 'r') as f:
+                    config_data = json.load(f)
+                
+                assert 'master_key' in config_data, "Config file contains master_key"
+                assert config_data['master_key'] != '**********', "Key not redacted"
+                assert config_data['master_key'] == master_key1, "Master key matches"
+                
+                # Clear the global config and load again
+                openhands_server.config._global_config = None
+                
+                # Load the config again (this should read from the file)
+                config2 = get_global_config()
+                master_key2 = config2.master_key.get_secret_value()
+                
+                # Verify the master key is the same
+                assert master_key1 == master_key2, "Master key should be preserved"
+                
+            finally:
+                # Restore the original environment variable
+                if original_config_path is not None:
+                    os.environ[CONFIG_FILE_PATH_ENV] = original_config_path
+                elif CONFIG_FILE_PATH_ENV in os.environ:
+                    del os.environ[CONFIG_FILE_PATH_ENV]


### PR DESCRIPTION
- Replace model_dump_json() with custom serialization that explicitly includes secret values
- Master key now persists correctly across server restarts instead of being redacted as '**********'
- Add comprehensive test case to verify master key persistence in config files
- Fix typo: 'comnfig' → 'config' in comment