### PR TITLE
Refactor SandboxContext to SandboxService following PR #41 pattern

### DIFF
--- a/openhands_server/config.py
+++ b/openhands_server/config.py
@@ -22,7 +22,7 @@ from openhands_server.event_callback.event_callback_context import (
 from openhands_server.event_callback.event_callback_result_context import (
     EventCallbackResultContextResolver,
 )
-from openhands_server.sandbox.sandbox_context import SandboxContextResolver
+from openhands_server.sandbox.sandbox_service import SandboxServiceResolver
 from openhands_server.sandbox.sandbox_spec_service import SandboxSpecServiceResolver
 from openhands_server.sandboxed_conversation.sandboxed_conversation_context import (
     SandboxedConversationContextResolver,
@@ -154,7 +154,7 @@ class AppServerConfig(OpenHandsModel):
     event: EventContextResolver | None = None
     event_callback: EventCallbackContextResolver | None = None
     event_callback_result: EventCallbackResultContextResolver | None = None
-    sandbox: SandboxContextResolver | None = None
+    sandbox: SandboxServiceResolver | None = None
     sandbox_spec: SandboxSpecServiceResolver | None = None
     sandboxed_conversation: SandboxedConversationContextResolver | None = None
     user: UserContextResolver | None = None

--- a/openhands_server/dependency.py
+++ b/openhands_server/dependency.py
@@ -10,7 +10,7 @@ from openhands_server.event_callback.event_callback_context import (
 from openhands_server.event_callback.event_callback_result_context import (
     EventCallbackResultContextResolver,
 )
-from openhands_server.sandbox.sandbox_context import SandboxContextResolver
+from openhands_server.sandbox.sandbox_service import SandboxServiceResolver
 from openhands_server.sandbox.sandbox_spec_service import SandboxSpecServiceResolver
 from openhands_server.sandboxed_conversation.sandboxed_conversation_context import (
     SandboxedConversationContextResolver,
@@ -28,7 +28,7 @@ class DependencyResolver:
     event: EventContextResolver
     event_callback: EventCallbackContextResolver
     event_callback_result: EventCallbackResultContextResolver
-    sandbox: SandboxContextResolver
+    sandbox: SandboxServiceResolver
     sandbox_spec: SandboxSpecServiceResolver
     sandboxed_conversation: SandboxedConversationContextResolver
     user: UserContextResolver
@@ -49,7 +49,7 @@ def get_dependency_resolver():
             or _get_event_callback_context_factory(),
             event_callback_result=config.event_callback_result
             or _get_event_callback_result_context_factory(),
-            sandbox=config.sandbox or _get_sandbox_context_factory(),
+            sandbox=config.sandbox or _get_sandbox_service_factory(),
             sandbox_spec=config.sandbox_spec or _get_sandbox_spec_service_factory(),
             sandboxed_conversation=config.sandboxed_conversation
             or _get_sandboxed_conversation_context_factory(),
@@ -82,12 +82,12 @@ def _get_event_callback_result_context_factory():
     return ctx.SQLAlchemyEventCallbackResultContextResolver()
 
 
-def _get_sandbox_context_factory():
+def _get_sandbox_service_factory():
     from openhands_server.sandbox import (
-        docker_sandbox_context as ctx,
+        docker_sandbox_service as ctx,
     )
 
-    return ctx.DockerSandboxContextResolver()
+    return ctx.DockerSandboxServiceResolver()
 
 
 def _get_sandbox_spec_service_factory():

--- a/openhands_server/sandbox/sandbox_service.py
+++ b/openhands_server/sandbox/sandbox_service.py
@@ -6,9 +6,9 @@ from openhands.sdk.utils.models import DiscriminatedUnionMixin
 from openhands_server.sandbox.sandbox_models import SandboxInfo, SandboxPage
 
 
-class SandboxContext(ABC):
+class SandboxService(ABC):
     """
-    Context for accessing sandboxes available to the current user in which
+    Service for accessing sandboxes available to the current user in which
     conversations may be run.
     """
 
@@ -59,16 +59,23 @@ class SandboxContext(ABC):
     # Lifecycle methods
 
     async def __aenter__(self):
-        """Start using this sandbox context"""
+        """Start using this sandbox service"""
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        """Stop using this sandbox context"""
+        """Stop using this sandbox service"""
 
 
-class SandboxContextResolver(DiscriminatedUnionMixin, ABC):
+class SandboxServiceResolver(DiscriminatedUnionMixin, ABC):
     @abstractmethod
-    def get_resolver(self) -> Callable:
+    def get_unsecured_resolver(self) -> Callable:
         """
-        Get a resolver which may be used to resolve an instance of sandbox context.
+        Get a resolver which may be used to resolve an instance of sandbox service.
+        """
+
+    @abstractmethod
+    def get_resolver_for_user(self) -> Callable:
+        """
+        Get a resolver which may be used to resolve an instance of sandbox service
+        limited to the current user.
         """


### PR DESCRIPTION
## Summary

This PR refactors the `SandboxContext` class to follow the same pattern as `SandboxSpecContext` → `SandboxSpecService` from PR #41, introducing the concept of secured and unsecured versions of the service through a resolver pattern.

## Changes Made

### Class Renames
- `SandboxContext` → `SandboxService`
- `DockerSandboxContext` → `DockerSandboxService`
- `SandboxContextResolver` → `SandboxServiceResolver`
- `DockerSandboxContextResolver` → `DockerSandboxServiceResolver`

### File Renames
- `sandbox_context.py` → `sandbox_service.py`
- `docker_sandbox_context.py` → `docker_sandbox_service.py`

### Resolver Pattern Implementation
- Added `get_resolver_for_user(user: User)` method for secured access
- Added `get_unsecured_resolver()` method for unsecured access
- Updated `DockerSandboxServiceResolver` to use shared `resolve()` method since Docker containers are single-user/unsecured

### Updated Dependencies and Usage
- Updated `dependency.py` with new factory functions and imports
- Updated `config.py` type annotations
- Updated all router files with new imports and parameter names
- Updated variable names from `sandbox_context` to `sandbox_service`

### Secured vs Unsecured Usage
- **All usages use secured resolver** (`get_resolver_for_user()`) **except `event_webhook_router.py`**
- **`event_webhook_router.py` uses unsecured resolver** (`get_unsecured_resolver()`) as specified in the requirements

## Testing
- All Python files compile successfully without syntax errors
- No remaining references to old class names found in codebase

## Related
- Follows the same pattern established in PR #41 for `SandboxSpecContext` → `SandboxSpecService`
- Maintains consistency across the codebase while introducing the secured/unsecured service concept

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/826f179707924e1698c71f7b217e14ea)