### PR TITLE
Enhance sandboxed conversation router with full search parameters and count endpoint

### DIFF
--- a/openhands_server/sandboxed_conversation/sandboxed_conversation_router.py
+++ b/openhands_server/sandboxed_conversation/sandboxed_conversation_router.py
@@ -1,5 +1,6 @@
 """Sandboxed Conversation router for OpenHands Server."""
 
+from datetime import datetime
 from typing import Annotated
 from uuid import UUID
 
@@ -26,6 +27,26 @@ sandboxed_conversation_service_dependency = Depends(
 
 @router.get("/search")
 async def search_sandboxed_conversations(
+    title__contains: Annotated[
+        str | None,
+        Query(title="Filter by title containing this string"),
+    ] = None,
+    created_at__gte: Annotated[
+        datetime | None,
+        Query(title="Filter by created_at greater than or equal to this datetime"),
+    ] = None,
+    created_at__lt: Annotated[
+        datetime | None,
+        Query(title="Filter by created_at less than this datetime"),
+    ] = None,
+    updated_at__gte: Annotated[
+        datetime | None,
+        Query(title="Filter by updated_at greater than or equal to this datetime"),
+    ] = None,
+    updated_at__lt: Annotated[
+        datetime | None,
+        Query(title="Filter by updated_at less than this datetime"),
+    ] = None,
     page_id: Annotated[
         str | None,
         Query(title="Optional next_page_id from the previously returned page"),
@@ -44,7 +65,49 @@ async def search_sandboxed_conversations(
     assert limit > 0
     assert limit <= 100
     return await sandboxed_conversation_service.search_sandboxed_conversations(
-        page_id=page_id, limit=limit
+        title__contains=title__contains,
+        created_at__gte=created_at__gte,
+        created_at__lt=created_at__lt,
+        updated_at__gte=updated_at__gte,
+        updated_at__lt=updated_at__lt,
+        page_id=page_id,
+        limit=limit,
+    )
+
+
+@router.get("/count")
+async def count_sandboxed_conversations(
+    title__contains: Annotated[
+        str | None,
+        Query(title="Filter by title containing this string"),
+    ] = None,
+    created_at__gte: Annotated[
+        datetime | None,
+        Query(title="Filter by created_at greater than or equal to this datetime"),
+    ] = None,
+    created_at__lt: Annotated[
+        datetime | None,
+        Query(title="Filter by created_at less than this datetime"),
+    ] = None,
+    updated_at__gte: Annotated[
+        datetime | None,
+        Query(title="Filter by updated_at greater than or equal to this datetime"),
+    ] = None,
+    updated_at__lt: Annotated[
+        datetime | None,
+        Query(title="Filter by updated_at less than this datetime"),
+    ] = None,
+    sandboxed_conversation_service: SandboxedConversationService = (
+        sandboxed_conversation_service_dependency
+    ),
+) -> int:
+    """Count sandboxed conversations matching the given filters"""
+    return await sandboxed_conversation_service.count_sandboxed_conversations(
+        title__contains=title__contains,
+        created_at__gte=created_at__gte,
+        created_at__lt=created_at__lt,
+        updated_at__gte=updated_at__gte,
+        updated_at__lt=updated_at__lt,
     )
 
 


### PR DESCRIPTION
## Summary

This PR enhances the sandboxed conversation router by adding comprehensive search filtering capabilities and implementing a count endpoint.

## Changes Made

### 1. Enhanced Search Endpoint (`/search`)
Added all search parameters from `SandboxedConversationService` to the router's search method:
- `title__contains`: Filter conversations by title containing a specific string
- `created_at__gte`: Filter by created_at greater than or equal to datetime
- `created_at__lt`: Filter by created_at less than datetime
- `updated_at__gte`: Filter by updated_at greater than or equal to datetime
- `updated_at__lt`: Filter by updated_at less than datetime

### 2. New Count Endpoint (`/count`)
Implemented a new `/count` endpoint that:
- Returns the total count of sandboxed conversations matching the given filters
- Uses the same filter parameters as the search endpoint for consistency
- Calls the `count_sandboxed_conversations` method from the service layer

### 3. Technical Improvements
- Added `datetime` import for proper type annotations
- Maintained consistent parameter naming and documentation
- Used FastAPI's `Query` annotations with descriptive titles for better API documentation

## API Changes

### Updated `/search` endpoint
```
GET /sandboxed-conversations/search?title__contains=example&created_at__gte=2023-01-01T00:00:00Z&limit=50
```

### New `/count` endpoint
```
GET /sandboxed-conversations/count?title__contains=example&created_at__gte=2023-01-01T00:00:00Z
```

## Testing

- Code compiles successfully without syntax errors
- All parameters are properly typed and documented
- Maintains backward compatibility with existing API usage

## Notes

This change brings the router in full alignment with the service layer's capabilities, enabling clients to perform more sophisticated filtering and counting operations on sandboxed conversations.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4dc79950ea554ec9817d5f77e0ca6392)